### PR TITLE
fix(modify): don't allow timeranges that exceed the working hour, lim…

### DIFF
--- a/src/commands/schedules/modify.js
+++ b/src/commands/schedules/modify.js
@@ -80,6 +80,13 @@ export default (bot, uri) => {
       start.milliseconds(0);
 
       if (command === 'out') {
+        const b = moment(wh.Timeranges[0].start, 'HH:mm');
+        const beginning = start.clone().hours(b.hours()).minutes(b.minutes());
+        start = moment.max(start, beginning);
+        const e = moment(timerange.end, 'HH:mm');
+        const finish = end.clone().hours(e.hours()).minutes(e.minutes());
+        end = moment.min(end, finish);
+
         const modification = {
           type: 'sub',
           start: start.toISOString(),

--- a/test/actions.js
+++ b/test/actions.js
@@ -39,7 +39,7 @@ describe('actions', function functions() {
         expect(msg.text).to.equal(bot.t('teamline.actions.remove.clear'));
 
         app._router.stack.length -= 1;
-        delete socket._events.message;
+        socket._events.message.length -= 1;
         done();
       });
 
@@ -68,7 +68,7 @@ describe('actions', function functions() {
       socket.on('message', message => {
         const msg = JSON.parse(message);
         expect(msg.text).to.equal(bot.t('teamline.actions.remove.remove', { action: 'some' }));
-        delete socket._events.message;
+        socket._events.message.length -= 1;
 
         app._router.stack.length -= 2;
         done();
@@ -103,7 +103,7 @@ describe('actions', function functions() {
           });
 
           app._router.stack.length -= 1;
-          delete socket._events.message;
+          socket._events.message.length -= 1;
           done();
         });
 
@@ -133,7 +133,7 @@ describe('actions', function functions() {
           });
 
           app._router.stack.length -= 1;
-          delete socket._events.message;
+          socket._events.message.length -= 1;
           done();
         });
 
@@ -166,7 +166,7 @@ describe('actions', function functions() {
           });
 
           app._router.stack.length -= 1;
-          delete socket._events.message;
+          socket._events.message.length -= 1;
           done();
         });
 
@@ -215,7 +215,7 @@ describe('actions', function functions() {
           });
 
           app._router.stack.length -= 3;
-          delete socket._events.message;
+          socket._events.message.length -= 1;
           done();
         });
 
@@ -248,7 +248,7 @@ describe('actions', function functions() {
             });
 
           app._router.stack.length -= 1;
-          delete socket._events.message;
+          socket._events.message.length -= 1;
           done();
         });
 

--- a/test/jobs.js
+++ b/test/jobs.js
@@ -90,7 +90,7 @@ describe('ask-for-actions', function functions() {
 
         expect(notified).to.be.ok;
         app._router.stack.length -= 4;
-        delete socket._events.message;
+        socket._events.message.length -= 1;
         done();
       });
 


### PR DESCRIPTION
…it them

fix(tests): don't remove all `socket`'s `message` listeners, as we want to reply to messages to avoid memory leak (waitForReply waits on the reply)
