### PR TITLE
feat(modify): ability to `out` a whole day

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "istanbul": "0.4.2",
     "mocha": "2.4.5",
     "sinon": "1.17.3",
-    "slack-bolt": "1.16.4",
+    "slack-bolt": "1.16.5",
     "ws": "1.0.1"
   },
   "dependencies": {

--- a/src/commands/schedules/available.js
+++ b/src/commands/schedules/available.js
@@ -15,7 +15,8 @@ export default (bot, uri) => {
     const [username, vdate] = message.match;
     const employee = await findEmployee(uri, bot, message, username);
 
-    const date = parseDate(bot, vdate).isValid() ? parseDate(bot, vdate) : moment();
+    const d = parseDate(bot, vdate);
+    const date = d.isValid() ? d : moment();
 
     const workhours = await get(`employee/${employee.id}/workhours`, {
       weekday: date.weekday(),
@@ -46,8 +47,11 @@ export default (bot, uri) => {
       return;
     }
 
-    const start = computed.Timeranges[0].start;
-    const end = computed.Timeranges[computed.Timeranges.length - 1].end;
+    const tr = computed.Timeranges.find(timerange =>
+      moment(timerange.start, 'HH:mm').isSameOrAfter(date)
+    );
+    const start = tr.start;
+    const end = tr.end;
 
     message.reply(t('available.range', { start: `*${start}*`, end: `*${end}*` }), {
       websocket: false,

--- a/src/commands/schedules/modify.js
+++ b/src/commands/schedules/modify.js
@@ -43,7 +43,11 @@ export default (bot, uri) => {
     if (command === 'in') {
       let start;
       let end;
-      if (date.range && !date.from.isValid()) {
+      if (date.range && !date.from.isValid() && /\b(?:for)\b/i.test(vdate)) {
+        start = moment(timerange.end, 'HH:mm');
+        end = date.to.isValid() ? start.clone().add(date.to.diff(moment()))
+                                : moment(timerange.end, 'HH:mm');
+      } else if (date.range && !date.from.isValid()) {
         start = moment(timerange.end, 'HH:mm');
         end = date.to.isValid() ? moment(date.to) : moment(timerange.end, 'HH:mm');
       } else if (date.range) {

--- a/src/commands/schedules/modify.js
+++ b/src/commands/schedules/modify.js
@@ -54,8 +54,6 @@ export default (bot, uri) => {
         const duration = moment(date).diff(moment());
         end = date.isValid() ? start.clone().add(duration) : null;
       }
-      end.milliseconds(0);
-      start.milliseconds(0);
 
       await post(`employee/${employee.id}/schedulemodification`, {
         type: 'add',
@@ -96,8 +94,6 @@ export default (bot, uri) => {
         }
         end = moment(timerange.end, 'HH:mm').dayOfYear(start.dayOfYear());
       }
-      // end.milliseconds(1);
-      // start.milliseconds(1);
 
       if (command === 'out') {
         const b = moment(wh.Timeranges[0].start, 'HH:mm');
@@ -138,8 +134,6 @@ export default (bot, uri) => {
 
         const tend = moment(timerange.end, 'HH:mm');
         const shiftEnd = tend.clone().add(moment(end).diff(start));
-        tend.milliseconds(0);
-        shiftEnd.milliseconds(0);
         const inModification = {
           type: 'add',
           start: tend.toISOString(),

--- a/src/commands/schedules/modify.js
+++ b/src/commands/schedules/modify.js
@@ -29,8 +29,7 @@ export default (bot, uri) => {
 
     let weekday;
     if (date && date.range) {
-      if (date.from.isValid()) weekday = date.from;
-      else weekday = date.to;
+      weekday = date.from.isValid() ? date.from : date.to;
     } else if (date.isValid()) {
       weekday = date;
     } else {

--- a/src/commands/schedules/modify.js
+++ b/src/commands/schedules/modify.js
@@ -25,9 +25,20 @@ export default (bot, uri) => {
       include: 'Timerange'
     });
 
-    const wh = _.find(workhours, { weekday: moment().weekday() }) || { Timeranges: [] };
-    const timerange = wh.Timeranges[wh.Timeranges.length - 1];
     const date = parseDate(bot, vdate);
+
+    let weekday;
+    if (date && date.range) {
+      if (date.from.isValid()) weekday = date.from;
+      else weekday = date.to;
+    } else if (date.isValid()) {
+      weekday = date;
+    } else {
+      weekday = moment();
+    }
+
+    let wh = _.find(workhours, { weekday: weekday.weekday() }) || { Timeranges: [] };
+    let timerange = wh.Timeranges[wh.Timeranges.length - 1];
 
     if (command === 'in') {
       let start;
@@ -63,21 +74,30 @@ export default (bot, uri) => {
     } else {
       let start;
       let end;
-      if (!date.range && /from|since/i.test(vdate)) {
+      if (!date.range && /\b(?:from|since)\b/i.test(vdate)) {
         start = date.isValid() ? moment(date) : moment();
-        end = moment(timerange.end, 'HH:mm');
+        end = moment(timerange.end, 'HH:mm').dayOfYear(start.dayOfYear());
       } else if (date.range && !date.from.isValid()) {
-        start = moment();
         end = date.to.isValid() ? moment(date.to) : moment(timerange.end, 'HH:mm');
+        start = moment().dayOfYear(end.dayOfYear());
       } else if (date.range) {
         start = moment(date.from);
         end = moment(date.to);
-      } else {
+      } else if (/\b(?:until|til|to)\b/i.test(vdate)) {
         start = moment();
         end = date.isValid() ? moment(date) : moment(timerange.end, 'HH:mm');
+      } else {
+        start = date.isValid() ? moment(date) : moment(timerange.start, 'HH:mm');
+        wh = _.find(workhours, { weekday: start.weekday() }) || { Timeranges: [] };
+        timerange = wh.Timeranges[wh.Timeranges.length - 1];
+        if (!timerange) {
+          message.reply(`You don't have a working hour on ${start.format('DD MMMM')}.`);
+          return;
+        }
+        end = moment(timerange.end, 'HH:mm').dayOfYear(start.dayOfYear());
       }
-      end.milliseconds(0);
-      start.milliseconds(0);
+      // end.milliseconds(1);
+      // start.milliseconds(1);
 
       if (command === 'out') {
         const b = moment(wh.Timeranges[0].start, 'HH:mm');

--- a/src/commands/schedules/work-hours.js
+++ b/src/commands/schedules/work-hours.js
@@ -8,9 +8,6 @@ import parseDate from '../../functions/parse-date';
 const DAY_COLORS = ['#687fe0', '#86e453', '#eb5d7a', '#34bae4', '#757f8c', '#ecf76e', '#ac58e0'];
 export default (bot, uri) => {
   const { get, post, del } = request(bot, uri);
-  const breakTimes = (_.get(bot.config, 'teamline.breaks') || []).map(time =>
-    ({ start: moment(time.start, 'HH:mm'), end: moment(time.end, 'HH:mm') })
-  );
 
   moment.relativeTimeThreshold('m', 60);
   moment.relativeTimeThreshold('h', Infinity);
@@ -159,29 +156,12 @@ export default (bot, uri) => {
         const start = moment(y.start, 'HH:mm');
         const end = moment(y.end, 'HH:mm');
 
-        const breaks = breakTimes.reduce((g, h) => {
-          if (start.isSameOrBefore(h.start) && end.isSameOrAfter(h.start) &&
-              start.isSameOrBefore(h.end) && end.isSameOrAfter(h.end)) {
-            return g + Math.abs(h.end.diff(h.start, 'minutes', true));
-          }
-
-          return g;
-        }, 0);
-
         const diff = end.diff(start, 'minutes', true);
-        return {
-          total: x.total + Math.abs(diff),
-          calculated: x.calculated + Math.abs(diff) - breaks,
-          breaks: x.breaks + breaks
-        };
-      }, { total: 0, calculated: 0, breaks: 0 });
+        return x + Math.abs(diff);
+      }, 0);
 
-      return {
-        total: a.total + innersum.total,
-        calculated: a.calculated + innersum.calculated,
-        breaks: a.breaks + innersum.breaks
-      };
-    }, { total: 0, calculated: 0, breaks: 0 });
+      return a + innersum;
+    }, 0);
 
     const list = sorted.map(({ weekday, Timeranges, modified }) => {
       const day = moment().weekday(weekday).format('dddd');
@@ -211,15 +191,8 @@ export default (bot, uri) => {
     };
 
     const summary = {
-      title: 'Summary',
-      fields: [{
-        title: 'Total',
-        value: textify(sum.total),
-        short: true
-      }, {
-        title: 'Calculated',
-        value: textify(sum.calculated)
-      }]
+      title: 'Total',
+      text: textify(sum)
     };
 
     list.push(summary);

--- a/src/functions/parse-date.js
+++ b/src/functions/parse-date.js
@@ -18,8 +18,11 @@ export default (bot, string, base = moment(), separators = SEPARATORS) => { // e
     };
 
     if (separator === 'for') {
-      if (!dates.from.isValid()) dates.from = moment();
-      dates.to = dates.from.clone().add(dates.to.diff(moment()));
+      if (!dates.from.isValid()) {
+        dates.to = moment().add(dates.to.diff(moment()));
+      } else {
+        dates.to = dates.from.clone().add(dates.to.diff(moment()));
+      }
     }
 
     if (dates.from > dates.to) {

--- a/src/functions/parse-date.js
+++ b/src/functions/parse-date.js
@@ -18,11 +18,9 @@ export default (bot, string, base = moment(), separators = SEPARATORS) => { // e
     };
 
     if (separator === 'for') {
-      if (!dates.from.isValid()) {
-        dates.to = moment().add(dates.to.diff(moment()));
-      } else {
-        dates.to = dates.from.clone().add(dates.to.diff(moment()));
-      }
+      dates.to = dates.from.isValid()
+                 ? dates.from.clone().add(dates.to.diff(moment()))
+                 : moment().add(dates.to.diff(moment()));
     }
 
     if (dates.from > dates.to) {

--- a/src/functions/workhours-modifications.js
+++ b/src/functions/workhours-modifications.js
@@ -36,7 +36,7 @@ export default (bot, workhours, modifications) => {
           const iS = moment(item.start, 'HH:mm').weekday(wh.weekday);
           const iE = moment(item.end, 'HH:mm').weekday(wh.weekday);
 
-          if (s.isSameOrAfter(iS)) {
+          if (s.isSameOrAfter(iS) && e.isSameOrBefore(iE)) {
             if (Math.abs(e.diff(iE), 'minutes')) {
               wh.Timeranges.push({
                 start: e.format('HH:mm'),
@@ -53,9 +53,11 @@ export default (bot, workhours, modifications) => {
     });
 
   const final = workhours.concat(addmodifications);
-  final.forEach(a => {
-    a.Timeranges = a.Timeranges.filter(({ start, end }) =>
+  final.forEach(wh => {
+    wh.Timeranges = wh.Timeranges.filter(({ start, end }) =>
       !moment(start, 'HH:mm').isSame(moment(end, 'HH:mm'))
+    ).sort((a, b) =>
+      moment(a.start, 'HH:mm').diff(moment(b.start, 'HH:mm'))
     );
   });
 

--- a/test/functions.js
+++ b/test/functions.js
@@ -473,17 +473,16 @@ describe('functions', function functions() {
     });
 
     it('should take the first part separated by `for` as base, and next part as duration', () => {
-      const tomorrow = moment().add(1, 'day').hours(0).minutes(0).seconds(0).milliseconds(0);
-      const first = tomorrow.toString();
-      const second = tomorrow.add(1, 'hour').toString();
+      const first = moment().add(1, 'day').hours(0).minutes(0).seconds(0).milliseconds(0);
+      const second = first.clone().add(1, 'hour');
       const range = parseDate(bot, 'tomorrow for 1 hour');
       expect(range.range).to.be.ok;
 
-      const from = range.from.toString();
-      const to = range.to.toString();
+      const from = range.from;
+      const to = range.to;
 
-      expect(first).to.equal(from);
-      expect(second).to.equal(to);
+      almostEqual(first, from);
+      almostEqual(second, to);
     });
 
     it('should return a range if the string is split using to|-|until|till', () => {
@@ -656,3 +655,5 @@ describe('functions', function functions() {
     _.set(bot.config, 'teamline.schedules.notification.mentionTeams', false);
   });
 });
+
+const almostEqual = (d1, d2) => expect(Math.abs(moment(d1).diff(d2, 'seconds'))).to.be.lt(2);

--- a/test/schedules.js
+++ b/test/schedules.js
@@ -296,7 +296,7 @@ describe('schedules', function functions() {
             });
 
             expect(request.body.type).to.equal('sub');
-            const start = moment().milliseconds(0);
+            const start = moment();
             const end = moment('12:00', 'HH:mm');
             almostEqual(request.body.start, start);
             almostEqual(request.body.end, end);
@@ -376,8 +376,8 @@ describe('schedules', function functions() {
             });
 
             expect(request.body.type).to.equal('sub');
-            const start = moment().milliseconds(0);
-            const end = moment().add(2, 'hours').milliseconds(0);
+            const start = moment();
+            const end = moment().add(2, 'hours');
             almostEqual(request.body.start, start);
             almostEqual(request.body.end, end);
 
@@ -414,8 +414,8 @@ describe('schedules', function functions() {
             });
 
             expect(request.body.type).to.equal('sub');
-            const start = moment('12:00', 'HH:mm').milliseconds(0);
-            const end = start.clone().add(2, 'hours').milliseconds(0);
+            const start = moment('12:00', 'HH:mm');
+            const end = start.clone().add(2, 'hours');
             almostEqual(request.body.start, start);
             almostEqual(request.body.end, end);
 
@@ -613,8 +613,8 @@ describe('schedules', function functions() {
             });
 
             expect(request.body.type).to.equal('add');
-            const start = moment('12:00', 'HH:mm').milliseconds(0);
-            const end = start.clone().add(2, 'hours').milliseconds(0);
+            const start = moment('12:00', 'HH:mm');
+            const end = start.clone().add(2, 'hours');
             almostEqual(request.body.start, start);
             almostEqual(request.body.end, end);
 
@@ -704,12 +704,12 @@ describe('schedules', function functions() {
           const duration = moment('12:00', 'HH:mm').diff(moment());
           const expected = [{
             type: 'sub',
-            start: moment().milliseconds(0).toISOString(),
+            start: moment().toISOString(),
             end: moment('12:00', 'HH:mm').toISOString()
           }, {
             type: 'add',
             start: moment('18:00', 'HH:mm').toISOString(),
-            end: moment('18:00', 'HH:mm').add(duration).milliseconds(0).toISOString()
+            end: moment('18:00', 'HH:mm').add(duration).toISOString()
           }];
           let i = 0;
 
@@ -810,12 +810,12 @@ describe('schedules', function functions() {
 
           const expected = [{
             type: 'sub',
-            start: moment().milliseconds(0).toISOString(),
-            end: moment().add(2, 'hours').milliseconds(0).toISOString()
+            start: moment().toISOString(),
+            end: moment().add(2, 'hours').toISOString()
           }, {
             type: 'add',
             start: moment('18:00', 'HH:mm').toISOString(),
-            end: moment('20:00', 'HH:mm').milliseconds(0).toISOString()
+            end: moment('20:00', 'HH:mm').toISOString()
           }];
           let i = 0;
 
@@ -861,12 +861,12 @@ describe('schedules', function functions() {
 
           const expected = [{
             type: 'sub',
-            start: moment('12:00', 'HH:mm').milliseconds(0).toISOString(),
-            end: moment('14:00', 'HH:mm').milliseconds(0).toISOString()
+            start: moment('12:00', 'HH:mm').toISOString(),
+            end: moment('14:00', 'HH:mm').toISOString()
           }, {
             type: 'add',
             start: moment('18:00', 'HH:mm').toISOString(),
-            end: moment('20:00', 'HH:mm').milliseconds(0).toISOString()
+            end: moment('20:00', 'HH:mm').toISOString()
           }];
           let i = 0;
 

--- a/test/schedules.js
+++ b/test/schedules.js
@@ -1095,4 +1095,4 @@ describe('schedules', function functions() {
   after(cleanup);
 });
 
-const almostEqual = (d1, d2) => expect(moment(d1).diff(d2, 'seconds')).to.be.lt(2);
+const almostEqual = (d1, d2) => expect(Math.abs(moment(d1).diff(d2, 'seconds'))).to.be.lt(2);


### PR DESCRIPTION
feat(parse-date): ability to set a base + duration time using `[base] for [duration]` syntax
fix(modify): use the date.from, date.to or date as the weekday for `timerange`
fix(workhours-modifications): fix a bug where the function would confuse multiple `out` modifications
fix(work-hours): sort timeranges based on their starting time
fix(work-hours): `breakTimes` are deprecated, modify the working hours instead if required
fix(available): show the next available timerange instead of the widest range possible
